### PR TITLE
Add MySQL support

### DIFF
--- a/wonitor/dbUtil.php
+++ b/wonitor/dbUtil.php
@@ -4,11 +4,14 @@
      * or   $wonitorDb = ['mysql:host=localhost;dbname=rounds', 'username', 'password'];
      * ./data is created if it does not exist
      */
-    $wonitorDb  = ['sqlite:./data/rounds.sqlite3'];
+    $wonitorDb = ['sqlite:./data/rounds.sqlite3'];
     $ns2plusDb = ['sqlite:./data/ns2plus.sqlite3'];
+    
+    // $wonitorDb  = ['mysql:host=yourhostname;dbname=wonitor_rounds', 'user', 'password'];
+    // $ns2plusDb =  ['mysql:host=yourhostname;dbname=wonitor_ns2plus', 'user', 'password'];
 
     function openDB($dbDef) {
-        try{
+        try {
           // Connect to database
           //$db = new PDO( $dbName );
           $db = (new ReflectionClass('PDO'))->newInstanceArgs($dbDef);
@@ -32,7 +35,19 @@
     }
     
     function databaseExists(& $dbDef) {
-        return file_exists( explode( ':', $dbDef[0] )[1] );
+        if (strpos($dbDef[0], 'sqlite') === 0) {
+            return file_exists( explode( ':', $dbDef[0] )[1] );
+        }
+        if (strpos($dbDef[0], 'mysql') === 0) {
+            try {
+                openDB($dbDef);
+                return true;
+            }
+            catch (Exception $e) {
+                return false;
+            }
+        }
+            return false;
     }
 
     // all fields listed here are query-able

--- a/wonitor/deathMap.php
+++ b/wonitor/deathMap.php
@@ -11,7 +11,7 @@
 <?php
   require_once 'dbUtil.php';
   $db = openDB( $ns2plusDb );
-  $query = 'SELECT serverId, name as [serverName] FROM ServerInfo GROUP BY serverId ORDER BY serverName;';
+  $query = 'SELECT serverId, name as serverName FROM ServerInfo GROUP BY serverId ORDER BY serverName;';
   $servers = $db->query( $query, PDO::FETCH_ASSOC )->fetchAll();
   $query = 'SELECT DISTINCT mapName AS map FROM RoundInfo;';
   $maps = $db->query( $query, PDO::FETCH_NUM )->fetchAll(PDO::FETCH_COLUMN, 0);

--- a/wonitor/index.php
+++ b/wonitor/index.php
@@ -13,20 +13,21 @@
 <?php
   require_once 'dbUtil.php';
   $db = openDB( $wonitorDb );
+
   if (isset($_GET['serverId'])) {
-    $query = 'SELECT serverId, serverName, COUNT(1) as rounds, CAST(AVG(averageSkill) as INT) as averageSkill FROM rounds WHERE serverId = :serverId';
+    $query = 'SELECT serverId, serverName, COUNT(1) as rounds, ROUND(AVG(averageSkill),0) as averageSkill FROM rounds WHERE serverId = :serverId';
     $statement = $db->prepare($query);
     $statement->bindValue(':serverId', $_GET['serverId']);
     $statement->setFetchMode(PDO::FETCH_ASSOC);
     $statement->execute();
     $servers = $statement->fetchAll();
   } else {
-    $query = 'SELECT serverId, serverName, COUNT(1) as rounds, CAST(AVG(averageSkill) as INT) as averageSkill FROM rounds GROUP BY serverId ORDER BY count(1) DESC';
+    $query = 'SELECT serverId, serverName, COUNT(1) as rounds, ROUND(AVG(averageSkill),0) as averageSkill FROM rounds GROUP BY serverId ORDER BY count(1) DESC';
     $servers = $db->query( $query, PDO::FETCH_ASSOC )->fetchAll();
   }
   // add total stats
   if (count($servers)>1) {
-    $query = 'SELECT COUNT(1) as rounds, CAST(AVG(averageSkill) as INT) as averageSkill FROM rounds';
+    $query = 'SELECT COUNT(1) as rounds, ROUND(AVG(averageSkill),0) as averageSkill FROM rounds';
     $allServers = $db->query( $query, PDO::FETCH_ASSOC )->fetch();
     $allServers['serverName'] = 'All Servers';
     $servers[] = $allServers;

--- a/wonitor/update.php
+++ b/wonitor/update.php
@@ -264,7 +264,7 @@
         }
 
         // PlayerStats
-        $insertStatement = 'INSERT OR IGNORE INTO PlayerStats (steamId) VALUES ( :steamId );';
+        $insertStatement = 'INSERT IGNORE INTO PlayerStats (steamId) VALUES ( :steamId );';
         $updateStatement = 'UPDATE PlayerStats SET
             playerName = :playerName,
             hiveSkill = :hiveSkill,
@@ -285,7 +285,7 @@
             kills = kills + :kills,
             deaths = deaths + :deaths,
             assists = assists + :assists,
-            killstreak = MAX(killstreak, :killstreak),
+            killstreak = GREATEST(killstreak, :killstreak),
             hits = hits + :hits,
             onosHits = onosHits + :onosHits,
             misses = misses + :misses,


### PR DESCRIPTION
## The problem:

`dbUtils.php` suggests in the top comment that MySQL is supported, but when you change either `$wonitorDb` or `$ns2plusDb` to a MySQL DSN, almost all functionality breaks.

A lot of parts in the code just assumes that sqlite is used, so I made some changes to make it work both with MySQL and SQLite.

### Changes
1. `databaseExists()` previously only checked for the sqlite file. Besides keeping the previous behavior for SQLite,  now if MySQL is used it checks that `openDB()` doesn't throw any exceptions.
2. MySQL and SQLite have different data types, so `CAST(field as INT)` occurences with the intent to round or group where changed to `ROUND(field,0)` to make it work for both.
3. `GLOB` and `NOT GLOB` are essentially the same as `LIKE` and `NOT LIKE`. I replace `_mt` and `_nm` to use `LIKE` and `NOT LIKE`, and `*` to `%`.
4. Naming a field as `[field]` in MySQL is not allowed. I changed all occurrences to just `field`
5. Some subqueries did not specify a table name, and MySQL is picky about duplicated column names, so I added them.